### PR TITLE
Expanded GetItemCount function but to the right branch this time

### DIFF
--- a/Code/ItemHandler.cs
+++ b/Code/ItemHandler.cs
@@ -142,41 +142,15 @@ namespace ArchipelagoRandomizer
 
 		public ItemData.Item GetItemData(APItem item)
 		{
-			return GetItemData(GetItemDataName(item));
+			int index = (int)item;
+			// Accomadate for gap before Card 1, needs to be updated if those slots get filled
+			if (index > 65) index += 34;
+            return GetItemData(index);
 		}
 
         public string GetItemDataName(APItem item)
         {
-            string itemName = "";
-            string[] words = Regex.Split(item.ToString(), @"(?<!^)(?=[A-Z])");
-            if (words[0].Contains("Card"))
-            {
-                words[0] = words[0].Insert(4, " ");
-            }
-            else if (words[0] == "Connection") words[0] += " -";
-
-            switch (item)
-            {
-                case APItem.BoxOfCrayons:
-                case APItem.TombOfSimulacrumKey:
-                case APItem.TombOfSimulacrumKeyRing:
-                    words[1] = "of";
-                    break;
-                case APItem.BigOldPileOLoot:
-                    words[3] = "o'";
-                    break;
-                case APItem.Card30JennyBunUnemployed:
-                    words = ["Card 30 - Jenny Bun (Unemployed)"];
-                    break;
-                case APItem.Card33JennyBerryVacation:
-                    words = ["Card 33 - Jenny Berry (Vacation)"];
-                    break;
-            }
-
-            itemName = string.Join(" ", words);
-            Plugin.Log.LogMessage($"Returning \"{itemName}\"");
-
-            return itemName;
+            return GetItemData(item).ItemName;
         }
 
         public void GiveItem(ItemData.Item item)
@@ -674,6 +648,11 @@ namespace ArchipelagoRandomizer
         RandomBuff,
         RandomDebuffTrap,
         BeeTrap,
+		Lightning,
+		MeteorShowerTrap,
+		BeeOnslaughtTrap,
+		FreeRangeSnowboardingTrap,
+		MatriarchTrap,
         ConnectionFluffyFieldsToSweetwaterCoast,
         ConnectionFluffyFieldsToFancyRuins,
         ConnectionFluffyFieldsToStarWoods,

--- a/Code/ItemHandler.cs
+++ b/Code/ItemHandler.cs
@@ -59,12 +59,18 @@ namespace ArchipelagoRandomizer
 
 		public int GetItemCount(ItemData.Item item, out bool isLevelItem)
 		{
-			isLevelItem = false;
-			if (item == null)
+            isLevelItem = false;
+
+            if (item == null)
 			{
 				Plugin.Log.LogError("Illegal item count requested! Returning a count of 0.");
 				return 0;
 			}
+
+			List<string> levelItems = new() { "chain", "tome", "amulet", "headband", "tracker" };
+
+            isLevelItem = item.Type == ItemTypes.Upgrade || levelItems.Contains(item.SaveFlag);
+
             Entity player = ModCore.Utility.GetPlayer();
 
             if (player == null || mainSaver == null)

--- a/Code/ItemHandler.cs
+++ b/Code/ItemHandler.cs
@@ -9,8 +9,9 @@ namespace ArchipelagoRandomizer
 {
 	public class ItemHandler : MonoBehaviour
 	{
+		public static List<ItemData.Item> itemData;
+
 		private static ItemHandler instance;
-		private static List<ItemData.Item> itemData;
 		private static Dictionary<string, int> dungeonKeyCounts;
 		private static bool hasInitialized;
 
@@ -59,12 +60,18 @@ namespace ArchipelagoRandomizer
 		public int GetItemCount(ItemData.Item item, out bool isLevelItem)
 		{
 			isLevelItem = false;
-			Entity player = ModCore.Utility.GetPlayer();
+			if (item == null)
+			{
+				Plugin.Log.LogError("Illegal item count requested! Returning a count of 0.");
+				return 0;
+			}
+            Entity player = ModCore.Utility.GetPlayer();
 
-			if (player == null || mainSaver == null)
+            if (player == null || mainSaver == null)
 				return 0;
 
-			if (item.Type == ItemTypes.Key)
+
+            if (item.Type == ItemTypes.Key)
 			{
 				string dungeonName = item.ItemName.Substring(0, item.ItemName.IndexOf("Key") - 1).Replace(" ", "");
 
@@ -97,15 +104,18 @@ namespace ArchipelagoRandomizer
 				return keyCount;
 			}
 
-			List<string> levelItems = new() { "chain", "tome", "amulet", "headband", "tracker" };
-			List<string> countItems = new() { "shards", "raft", "potions", "evilKeys" };
+            if (item.ItemName.Contains("Outfit") && mainSaver.WorldStorage.HasData(item.SaveFlag))
+			{
+				return 1;
+            }
 
-			isLevelItem = item.Type == ItemTypes.Upgrade || levelItems.Contains(item.SaveFlag);
+            if (item.Type == ItemTypes.Card)
+			{
+				var cardSaver = mainSaver.GetSaver("/local/cards");
+				return cardSaver.LoadInt(item.SaveFlag);
+            }
 
-			if (isLevelItem || countItems.Contains(item.SaveFlag))
-				return player.GetStateVariable(item.SaveFlag);
-
-			return 0;
+            return player.GetStateVariable(item.SaveFlag);
 		}
 
 		public ItemData.Item GetItemData(string itemName)
@@ -124,7 +134,46 @@ namespace ArchipelagoRandomizer
 			return itemData.Find(item => item.Offset == offset);
 		}
 
-		public void GiveItem(ItemData.Item item)
+		public ItemData.Item GetItemData(APItem item)
+		{
+			return GetItemData(GetItemDataName(item));
+		}
+
+        public string GetItemDataName(APItem item)
+        {
+            string itemName = "";
+            string[] words = Regex.Split(item.ToString(), @"(?<!^)(?=[A-Z])");
+            if (words[0].Contains("Card"))
+            {
+                words[0] = words[0].Insert(4, " ");
+            }
+            else if (words[0] == "Connection") words[0] += " -";
+
+            switch (item)
+            {
+                case APItem.BoxOfCrayons:
+                case APItem.TombOfSimulacrumKey:
+                case APItem.TombOfSimulacrumKeyRing:
+                    words[1] = "of";
+                    break;
+                case APItem.BigOldPileOLoot:
+                    words[3] = "o'";
+                    break;
+                case APItem.Card30JennyBunUnemployed:
+                    words = ["Card 30 - Jenny Bun (Unemployed)"];
+                    break;
+                case APItem.Card33JennyBerryVacation:
+                    words = ["Card 33 - Jenny Berry (Vacation)"];
+                    break;
+            }
+
+            itemName = string.Join(" ", words);
+            Plugin.Log.LogMessage($"Returning \"{itemName}\"");
+
+            return itemName;
+        }
+
+        public void GiveItem(ItemData.Item item)
 		{
 			StartCoroutine(DoGiveItem(item));
 		}
@@ -506,4 +555,133 @@ namespace ArchipelagoRandomizer
 			}
 		}
 	}
+
+    public enum APItem
+    {
+        ProgressiveMelee,
+        ProgressiveForceWand,
+        ProgressiveDynamite,
+        ProgressiveIceRing,
+        ProgressiveChain,
+        ForceWandUpgrade,
+        DynamiteUpgrade,
+        IceRingUpgrade,
+        ChainUpgrade,
+        Roll,
+        ProgressiveTracker,
+        ProgressiveHeadband,
+        ProgressiveAmulet,
+        ProgressiveTome,
+        SecretShard,
+        ForbiddenKey,
+        Lockpick,
+        BoxOfCrayons,
+        CaveScroll,
+        PortalWorldScroll,
+        YellowHeart,
+        RaftPiece,
+        PillowFortKey,
+        PillowFortKeyRing,
+        SandCastleKey,
+        SandCastleKeyRing,
+        ArtExhibitKey,
+        ArtExhibitKeyRing,
+        TrashCaveKey,
+        TrashCaveKeyRing,
+        FloodedBasementKey,
+        FloodedBasementKeyRing,
+        PotassiumMineKey,
+        PotassiumMineKeyRing,
+        BoilingGraveKey,
+        BoilingGraveKeyRing,
+        GrandLibraryKey,
+        GrandLibraryKeyRing,
+        SunkenLabyrinthKey,
+        SunkenLabyrinthKeyRing,
+        MachineFortressKey,
+        MachineFortressKeyRing,
+        DarkHypostyleKey,
+        DarkHypostyleKeyRing,
+        TombOfSimulacrumKey,
+        TombOfSimulacrumKeyRing,
+        SyncopeKey,
+        SyncopeKeyRing,
+        BottomlessTowerKey,
+        BottomlessTowerKeyRing,
+        AntigramKey,
+        AntigramKeyRing,
+        QuietusKey,
+        QuietusKeyRing,
+        JennyDewOutfit,
+        SwimsuitOutfit,
+        TippsieOutfit,
+        LittleDudeOutfit,
+        TigerJennyOutfit,
+        IttleDew1Outfit,
+        DelinquintOutfit,
+        JennyBerryOutfit,
+        ApatheticFrogOutfit,
+        ThatGuyOutfit,
+        BigOldPileOLoot,
+        ImpossibleGatesPass,
+        Card1Fishbun,
+        Card2StupidBee,
+        Card3SafetyJenny,
+        Card4Shellbun,
+        Card5Spikebun,
+        Card6FeralGate,
+        Card7CandySnake,
+        Card8HermitLegs,
+        Card9Ogler,
+        Card10Hyperdusa,
+        Card11EvilEasel,
+        Card12Warnip,
+        Card13Octacle,
+        Card14Rotnip,
+        Card15BeeSwarm,
+        Card16Volcano,
+        Card17JennyShark,
+        Card18SwimmyRoger,
+        Card19Bunboy,
+        Card20Spectre,
+        Card21ReturnOfBrutus,
+        Card22Jelly,
+        Card23Skullnip,
+        Card24SlayerJenny,
+        Card25Titan,
+        Card26ChillyRoger,
+        Card27JennyFlower,
+        Card28Hexrot,
+        Card29JennyMole,
+        Card30JennyBunUnemployed,
+        Card31JennyCat,
+        Card32JennyMermaid,
+        Card33JennyBerryVacation,
+        Card34Mapman,
+        Card35Cyberjenny,
+        Card36LeBiadlo,
+        Card37Lenny,
+        Card38PasselCarver,
+        Card39Tippsie,
+        Card40IttleDew,
+        Card41NappingFly,
+        RandomBuff,
+        RandomDebuffTrap,
+        BeeTrap,
+        ConnectionFluffyFieldsToSweetwaterCoast,
+        ConnectionFluffyFieldsToFancyRuins,
+        ConnectionFluffyFieldsToStarWoods,
+        ConnectionFluffyFieldsToSlipperSlope,
+        ConnectionFluffyFieldsToPepperpainPrairie,
+        ConnectionSweetwaterCoastToFancyRuins,
+        ConnectionSweetwaterCoastToStarWoods,
+        ConnectionSweetwaterCoastToSlipperySlope,
+        ConnectionFancyRuinsToStarWoods,
+        ConnectionFancyRuinsToPepperpainPrairie,
+        ConnectionFancyRuinsToFrozenCourt,
+        ConnectionStarWoodsToFrozenCourt,
+        ConnectionSlipperySlopeToPepperpainPrairie,
+        ConnectionSlipperySlopeToLonelyRoad,
+        Potion
+    }
 }

--- a/Code/MessageBoxHandler.cs
+++ b/Code/MessageBoxHandler.cs
@@ -149,7 +149,7 @@ namespace ArchipelagoRandomizer
 			{
 				int count = ItemHandler.Instance.GetItemCount(item, out bool isLevelItem);
 
-				if (count == 0)
+				if (count <= 1)
 					return "!";
 
 				if (isLevelItem)

--- a/Code/TestCommand.cs
+++ b/Code/TestCommand.cs
@@ -1,4 +1,5 @@
 ﻿using ModCore;
+using System;
 using System.IO;
 using UnityEngine;
 
@@ -20,67 +21,14 @@ namespace ArchipelagoRandomizer
             DebugMenuManager.AddCommands(this);
         }
 
-        [DebugMenuCommand(commandName:"test")]
+        [DebugMenuCommand(commandName:"test", caseSensitive:true)]
         private void SendTestCommand(string[] args)
         {
-            string obj = "Forbidden Key";
             if (args.Length > 0)
             {
-                switch (args[0])
-                {
-                    case "0":
-                        obj = "Pillow Fort Key";
-                        break;
-                    case "1":
-
-                        obj = "Sand Castle Key";
-                        break;
-                    case "2":
-                        obj = "Art Exhibit Key";
-                        break;
-                    case "3":
-                        obj = "Trash Cave Key";
-                        break;
-                    case "4":
-                        obj = "Flooded Basement Key";
-                        break;
-                    case "5":
-                        obj = "Potassium Mine Key";
-                        break;
-                    case "6":
-                        obj = "Boiling Grave Key";
-                        break;
-                    case "7":
-                        obj = "Grand Library Key";
-                        break;
-                    case "8":
-                        obj = "Sunken Labyrinth Key";
-                        break;
-                    case "9":
-                        obj = "Machine Fortress Key";
-                        break;
-                    case "10":
-                        obj = "Dark Hypostyle Key";
-                        break;
-                    case "11":
-                        obj = "Tomb of Simulacrum Key";
-                        break;
-                    case "12":
-                        obj = "Syncope Key";
-                        break;
-                    case "13":
-                        obj = "Antigram Key";
-                        break;
-                    case "14":
-                        obj = "Bottomless Tower Key";
-                        break;
-                    case "15":
-                        obj = "Quietus Key";
-                        break;
-                }
+                string item = string.Join(" ", args);
+                DebugMenuManager.LogToConsole($"You have {ItemHandler.Instance.GetItemCount(ItemHandler.Instance.GetItemData(item), out _)} of {item}");
             }
-            GameObject logo = GameObject.Instantiate(FreestandingReplacer.GetModelPreview(obj));
-            logo.transform.position = ModCore.Utility.GetPlayer().transform.position;
         }
     }
 }


### PR DESCRIPTION
ItemHandler has been enhanced with the following:

* An `APItem` enum (along with a corresponding `GetItemData`), allowing you to request a specific item without the uncertainty of a string or looking up a count in the offset table
* A new `GetItemDataName` method to get the item name from an APItem as it appears in the itemName field of the corresponding entry in itemData.json
* `GetItemCount` has been improved to now allow retrieving the count of any type of item, not just items with levels or maximum counts greater than 1

The MessageBoxHandler has also been changed to accommodate the change.