### PR TITLE
implement player position tracking

### DIFF
--- a/Code/APHandler.cs
+++ b/Code/APHandler.cs
@@ -7,6 +7,7 @@ using ModCore;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using UnityEngine;
 
 namespace ArchipelagoRandomizer
 {
@@ -140,6 +141,32 @@ namespace ArchipelagoRandomizer
 				return null;
 
 			return scoutedItems.Find(x => x.LocationId - forLocation.Offset == baseId);
+		}
+
+		public void SetPosition(Vector2 position)
+		{
+			if (!IsConnected)
+			{
+				return;
+			}
+
+			var key = $"id2.pos.{CurrentPlayer.Slot}";
+			var value = $"{(int)position.x},{(int)position.y}";
+
+			Session.DataStorage[key] = value;
+		}
+
+		public void SetLevelName(string levelName)
+		{
+			if (!IsConnected)
+			{
+				return;
+			}
+
+			var key = $"id2.levelName.{CurrentPlayer.Slot}";
+			var value = levelName;
+
+			Session.DataStorage[key] = value;
 		}
 
 		private bool TryCreateSession(string url, out string errorMessage)

--- a/Code/GPS.cs
+++ b/Code/GPS.cs
@@ -44,9 +44,9 @@ namespace ArchipelagoRandomizer
             APHandler.Instance.SetLevelName(levelName);
         }
 
-        public void OnEntityUpdate(Entity entity)
+        public void OnPlayerGetMoveDir(PlayerController playerController)
         {
-            if (entity != player)
+            if (!playerController.isMoving)
             {
                 return;
             }

--- a/Code/GPS.cs
+++ b/Code/GPS.cs
@@ -4,18 +4,41 @@ using UnityEngine;
 
 namespace ArchipelagoRandomizer
 {
-    public class GPS
+    public class GPS : IDisposable
     {
         private static readonly TimeSpan updateInterval = TimeSpan.FromSeconds(1);
-        public static GPS Instance = new();
+        private static GPS instance = null;
+        public static GPS Instance
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    instance = new();
+                }
+
+                return instance;
+            }
+        }
+
         private Stopwatch UpdateTimer = Stopwatch.StartNew();
 
         Entity player;
 
         GPS()
         {
+            APHandler.Instance.OnDisconnect += Dispose;
             Events.OnPlayerSpawn += OnPlayerSpawn;
             Events.OnRoomChanged += OnRoomChanged;
+        }
+
+        public void Dispose()
+        {
+            Plugin.Log.LogMessage("Disposing the GPS");
+            APHandler.Instance.OnDisconnect -= Dispose;
+            Events.OnPlayerSpawn -= OnPlayerSpawn;
+            Events.OnRoomChanged -= OnRoomChanged;
+            instance = null;
         }
 
         private Vector2 GetPosition()

--- a/Code/GPS.cs
+++ b/Code/GPS.cs
@@ -1,0 +1,74 @@
+using System;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.UI;
+
+namespace ArchipelagoRandomizer
+{
+    public class GPS
+    {
+        private const float minRequiredDistanceForUpdate = 3.0f;
+        public static GPS Instance = new();
+        private Vector2 lastPosition = Vector2.zero;
+
+
+        Entity player;
+
+        GPS()
+        {
+            Events.OnPlayerSpawn += OnPlayerSpawn;
+            Events.OnRoomChanged += OnRoomChanged;
+        }
+
+        private Vector2 GetPosition()
+        {
+            if (player == null)
+            {
+                return Vector2.zero;
+            }
+
+            return new Vector2(
+                player.transform.position.x,
+                player.transform.position.z
+            );
+        }
+
+        private void OnPlayerSpawn(Entity player, GameObject _camera, PlayerController _controller)
+        {
+            this.player = player;
+            UpdatePosition();
+        }
+
+        private void OnRoomChanged(Entity _entity, LevelRoom toRoom, LevelRoom _fromRoom, EntityEventsOwner.RoomEventData _data)
+        {
+            var levelName = toRoom.LevelRoot.LevelData.LevelName;
+            Plugin.Log.LogMessage($"YOOO, level changed to `{levelName}`");
+            APHandler.Instance.SetLevelName(levelName);
+        }
+
+        public void OnEntityUpdate(Entity entity)
+        {
+            if (entity != player)
+            {
+                return;
+            }
+
+            UpdatePosition();
+        }
+
+        public void UpdatePosition()
+        {
+            var position = GetPosition();
+            var distance = Vector2.Distance(position, lastPosition);
+
+            if (distance < minRequiredDistanceForUpdate)
+            {
+                return;
+            }
+
+            APHandler.Instance.SetPosition(position);
+
+            lastPosition = position;
+        }
+    }
+}

--- a/Code/GPS.cs
+++ b/Code/GPS.cs
@@ -40,7 +40,6 @@ namespace ArchipelagoRandomizer
         private void OnRoomChanged(Entity _entity, LevelRoom toRoom, LevelRoom _fromRoom, EntityEventsOwner.RoomEventData _data)
         {
             var levelName = toRoom.LevelRoot.LevelData.LevelName;
-            Plugin.Log.LogMessage($"YOOO, level changed to `{levelName}`");
             APHandler.Instance.SetLevelName(levelName);
         }
 

--- a/Code/GPS.cs
+++ b/Code/GPS.cs
@@ -1,16 +1,14 @@
 using System;
+using System.Diagnostics;
 using UnityEngine;
-using UnityEngine.SceneManagement;
-using UnityEngine.UI;
 
 namespace ArchipelagoRandomizer
 {
     public class GPS
     {
-        private const float minRequiredDistanceForUpdate = 3.0f;
+        private static readonly TimeSpan updateInterval = TimeSpan.FromSeconds(1);
         public static GPS Instance = new();
-        private Vector2 lastPosition = Vector2.zero;
-
+        private Stopwatch UpdateTimer = Stopwatch.StartNew();
 
         Entity player;
 
@@ -58,17 +56,15 @@ namespace ArchipelagoRandomizer
 
         public void UpdatePosition()
         {
-            var position = GetPosition();
-            var distance = Vector2.Distance(position, lastPosition);
-
-            if (distance < minRequiredDistanceForUpdate)
+            if (UpdateTimer.Elapsed < updateInterval)
             {
                 return;
             }
 
-            APHandler.Instance.SetPosition(position);
+            UpdateTimer.Reset();
+            UpdateTimer.Start();
 
-            lastPosition = position;
+            APHandler.Instance.SetPosition(GetPosition());
         }
     }
 }

--- a/Code/Patches.cs
+++ b/Code/Patches.cs
@@ -162,15 +162,15 @@ namespace ArchipelagoRandomizer
 		}
 
 		[HarmonyPostfix]
-		[HarmonyPatch(typeof(Entity), "IUpdatable.UpdateObject")]
-		public static void Entity_IUpdatable_UpdateObject_Patch(Entity __instance)
+		[HarmonyPatch(typeof(PlayerController), nameof(PlayerController.GetMoveDir))]
+		public static void PlayerController_GetMoveDir_Patch(PlayerController __instance)
 		{
 			if (!ItemRandomizer.IsActive)
 			{
 				return;
 			}
 
-			GPS.Instance.OnEntityUpdate(__instance);
+			GPS.Instance.OnPlayerGetMoveDir(__instance);
 		}
 
 		// KEPT AS REFERENCE SINCE THIS WAS PAIN

--- a/Code/Patches.cs
+++ b/Code/Patches.cs
@@ -161,6 +161,13 @@ namespace ArchipelagoRandomizer
 			APMenuStuff.Instance.DeleteAPDataFile();
 		}
 
+		[HarmonyPostfix]
+		[HarmonyPatch(typeof(Entity), "IUpdatable.UpdateObject")]
+		public static void Entity_IUpdatable_UpdateObject_Patch(Entity __instance)
+		{
+			GPS.Instance.OnEntityUpdate(__instance);
+		}
+
 		// KEPT AS REFERENCE SINCE THIS WAS PAIN
 
 		//[HarmonyPatch(typeof(SpawnItemEventObserver))]

--- a/Code/Patches.cs
+++ b/Code/Patches.cs
@@ -165,6 +165,11 @@ namespace ArchipelagoRandomizer
 		[HarmonyPatch(typeof(Entity), "IUpdatable.UpdateObject")]
 		public static void Entity_IUpdatable_UpdateObject_Patch(Entity __instance)
 		{
+			if (!ItemRandomizer.IsActive)
+			{
+				return;
+			}
+
 			GPS.Instance.OnEntityUpdate(__instance);
 		}
 


### PR DESCRIPTION
This PR adds a basic implementation of player position tracking so that Trackers can show the current position of the player (or at least switch to the currently relevant map).
~~An update of the player position is sent to the AP server every time the player has moved 3 units of distance.~~
An update of the player position is sent to the AP server every second.
An update to the current level name is sent whenever the player moves between rooms.
This could be expanded to include the room name in the future.