### PR TITLE
Temporary disable player position tracking

### DIFF
--- a/Code/APHandler.cs
+++ b/Code/APHandler.cs
@@ -153,7 +153,8 @@ namespace ArchipelagoRandomizer
 			var key = $"id2.pos.{CurrentPlayer.Slot}";
 			var value = $"{(int)position.x},{(int)position.y}";
 
-			Session.DataStorage[key] = value;
+			// TODO: Add workaround for DataStorage writes causing lags
+			// Session.DataStorage[key] = value;
 		}
 
 		public void SetLevelName(string levelName)


### PR DESCRIPTION
Position tracking currently causes the game to stutter whenever a position update is sent to the AP server (i.e. once every second while moving).
The underlying issue seems to be related to the websocket's SendPacketAsync blocking more than it should.
To work around that issue, this PR disables position tracking until I've implemented a better workaround or a proper fix.
Note: The level tracking of the player suffers from the same issue, but I'll keep it enabled because it is only barely noticable.