### PR TITLE
Chest color changes

### DIFF
--- a/Code/ChestReplacer.cs
+++ b/Code/ChestReplacer.cs
@@ -27,8 +27,8 @@ namespace ArchipelagoRandomizer
 				new ChestCrystalColorData.CrystalColors("DarkGrey", "DarkGrey", "LightGrey"))
 			},
 			{ new("Junk", true,
-				new ChestCrystalColorData.ChestColors("Burgundy", "Grey", "Grey"),
-				new ChestCrystalColorData.CrystalColors("Burgundy", "Burgundy", "LightGrey"))
+				new ChestCrystalColorData.ChestColors("LightGrey", "Grey", "Grey"),
+				new ChestCrystalColorData.CrystalColors("Silver", "Silver", "Grey"))
 			},
 			{ new("Filler", false,
 				new ChestCrystalColorData.ChestColors("Cyan", "Grey", "Grey"),

--- a/Code/ChestReplacer.cs
+++ b/Code/ChestReplacer.cs
@@ -46,6 +46,10 @@ namespace ArchipelagoRandomizer
 				new ChestCrystalColorData.ChestColors("Orange", "DarkYellow", "Gold"),
 				new ChestCrystalColorData.CrystalColors("Orange", "Orange", "Yellow"))
 			},
+			{ new("RegionConnector", false,
+				new ChestCrystalColorData.ChestColors("Orange", "Grey", "Grey"),
+				new ChestCrystalColorData.CrystalColors("Orange", "Orange", "Orange"))
+			},
 			{ new("Empty", false,
 				new ChestCrystalColorData.ChestColors("LightGrey", "Grey", "Grey"),
 				new ChestCrystalColorData.CrystalColors("Silver", "Silver", "Grey"))
@@ -103,6 +107,8 @@ namespace ArchipelagoRandomizer
 					if (item.Type == ItemHandler.ItemTypes.Key || item.Type == ItemHandler.ItemTypes.Keyring)
 						colors = chestCrystalColors.Find(x => x.flag == "Key");
 					else if (item.Type == ItemHandler.ItemTypes.Shard)
+						colors = chestCrystalColors.Find(x => x.flag == item.Type.ToString());
+					else if (item.Type == ItemHandler.ItemTypes.RegionConnector)
 						colors = chestCrystalColors.Find(x => x.flag == item.Type.ToString());
 					else
 						colors = chestCrystalColors.Find(x => x.flag == item.Flag.ToString());

--- a/Code/ChestReplacer.cs
+++ b/Code/ChestReplacer.cs
@@ -20,7 +20,7 @@ namespace ArchipelagoRandomizer
 			},
 			{ new("Minor", true,
 				new ChestCrystalColorData.ChestColors("Brown", "DarkYellow", "Gold"),
-				new ChestCrystalColorData.CrystalColors("Brown", "Brown", "Burgundy"))
+				new ChestCrystalColorData.CrystalColors("Brown", "Brown", "Yellow"))
 			},
 			{ new("Shard", true,
 				new ChestCrystalColorData.ChestColors("DarkGrey", "Grey", "Grey"),
@@ -28,7 +28,7 @@ namespace ArchipelagoRandomizer
 			},
 			{ new("Junk", true,
 				new ChestCrystalColorData.ChestColors("Burgundy", "Grey", "Grey"),
-				new ChestCrystalColorData.CrystalColors("Silver", "Burgundy", "LightGrey"))
+				new ChestCrystalColorData.CrystalColors("Silver", "Silver", "Burgundy"))
 			},
 			{ new("Filler", false,
 				new ChestCrystalColorData.ChestColors("Cyan", "Grey", "Grey"),

--- a/Code/ChestReplacer.cs
+++ b/Code/ChestReplacer.cs
@@ -27,8 +27,8 @@ namespace ArchipelagoRandomizer
 				new ChestCrystalColorData.CrystalColors("DarkGrey", "DarkGrey", "LightGrey"))
 			},
 			{ new("Junk", true,
-				new ChestCrystalColorData.ChestColors("LightGrey", "Grey", "Grey"),
-				new ChestCrystalColorData.CrystalColors("Silver", "Silver", "Grey"))
+				new ChestCrystalColorData.ChestColors("Burgundy", "Grey", "Grey"),
+				new ChestCrystalColorData.CrystalColors("Silver", "Burgundy", "LightGrey"))
 			},
 			{ new("Filler", false,
 				new ChestCrystalColorData.ChestColors("Cyan", "Grey", "Grey"),
@@ -45,10 +45,6 @@ namespace ArchipelagoRandomizer
 			{ new("Advancement", false,
 				new ChestCrystalColorData.ChestColors("Orange", "DarkYellow", "Gold"),
 				new ChestCrystalColorData.CrystalColors("Orange", "Orange", "Yellow"))
-			},
-			{ new("RegionConnector", false,
-				new ChestCrystalColorData.ChestColors("Orange", "Grey", "Grey"),
-				new ChestCrystalColorData.CrystalColors("Orange", "Orange", "Orange"))
 			},
 			{ new("Empty", false,
 				new ChestCrystalColorData.ChestColors("LightGrey", "Grey", "Grey"),
@@ -79,8 +75,13 @@ namespace ArchipelagoRandomizer
 		{
 			ItemHandler.ItemData.Item item = ItemRandomizer.Instance.GetItemForLocation(SceneManager.GetActiveScene().name, dummyAction._saveName, out var scoutedItemInfo);
 
-			// Leave vanila if major
-			if (item != null && CheckItemFlags(item, ItemHandler.ItemFlags.Major))
+			// Leave vanilla if major, including region connectors
+			if (
+				item != null && (
+					CheckItemFlags(item, ItemHandler.ItemFlags.Major)
+					|| item.Type == ItemHandler.ItemTypes.RegionConnector
+				)
+			)
 				return;
 
 			ChestCrystalColorData colors = null;
@@ -107,8 +108,6 @@ namespace ArchipelagoRandomizer
 					if (item.Type == ItemHandler.ItemTypes.Key || item.Type == ItemHandler.ItemTypes.Keyring)
 						colors = chestCrystalColors.Find(x => x.flag == "Key");
 					else if (item.Type == ItemHandler.ItemTypes.Shard)
-						colors = chestCrystalColors.Find(x => x.flag == item.Type.ToString());
-					else if (item.Type == ItemHandler.ItemTypes.RegionConnector)
 						colors = chestCrystalColors.Find(x => x.flag == item.Type.ToString());
 					else
 						colors = chestCrystalColors.Find(x => x.flag == item.Flag.ToString());


### PR DESCRIPTION
My goal here is to fix two things:

- Burgundy is too visually similar to red and brown, but means something very different
- Region connectors did not have their own color

My goal was not to experiment with new color combinations -- there are already a lot to keep track of -- but to combine them with under-used existing ones of similar importance.

As the color scheme for RegionConnectors, I found the "NeverExclude" Archipelago category, which I don't think I've encountered before. Its orange and gray color scheme is like "Advancement" but slightly distinct, which seems perfect for region connectors.

I made Junk gray instead of burgundy, using the same colors as Empty. To me, Empty is a kind of Junk anyway.