### PR TITLE
Fix: Trap Item Names

### DIFF
--- a/Data/itemData.json
+++ b/Data/itemData.json
@@ -831,14 +831,14 @@
 			"type": "Lightning"
 		},
 		{
-			"itemName": "Eruption",
+			"itemName": "Meteor Shower Trap",
 			"iconName": "Custom/APTrap",
 			"offset": 145,
 			"type": "Trap",
 			"trapType": "Eruption"
 		},
 		{
-			"itemName": "Bee Onslaught",
+			"itemName": "Bee Onslaught Trap",
 			"iconName": "Custom/APTrap",
 			"offset": 146,
 			"type": "Trap",
@@ -852,7 +852,7 @@
 			"trapType": "Snowboarding"
 		},
 		{
-			"itemName": "Matriarch",
+			"itemName": "Matriarch Trap",
 			"iconName": "Custom/APTrap",
 			"offset": 148,
 			"type": "Trap",


### PR DESCRIPTION
# Summary

Fixes the names of a few traps that didn't match their AP definitions. This should resolve the bug mentioned in issue #45.

# Details

When syncing items, the [APHandler](https://github.com/Extra-2-Dew/ArchipelagoRandomizer/blob/main/Code/APHandler.cs#L130 ) uses the AP name of an item to check the save file for how many have been obtained. Then if an item needs to be granted, the [ItemHandler](https://github.com/Extra-2-Dew/ArchipelagoRandomizer/blob/main/Code/ItemHandler.cs#L266) via the [ItemRandomizer](https://github.com/Extra-2-Dew/ArchipelagoRandomizer/blob/main/Code/ItemRandomizer.cs#L201) use the name from item data to update the number obtained in the save file.

If the item names do not match, such as in this case, duplicates will be granted and the total count will be incremented higher than it should. As a result, item sync will fail until enough new items are received to pass [this check](https://github.com/Extra-2-Dew/ArchipelagoRandomizer/blob/main/Code/ItemHandler.cs#L266), at which point duplicates will be granted again and the cycle will continue.

# Testing

I am currently participating in a multiworld and experienced this issue multiple times, so I decided to test against my current save file.

1. I made this fix in my local copy of this mod.
2. After starting the game to make sure Steam cloud sync wouldn't overwrite my changes, I manually edited the relevant save file to lower the total item obtained count to 1 below the current server count.
3. I loaded the file and observed that all of the duplicate traps were granted.
4. I verified that the save file now had item obtained counts for those traps under the corrected item names.
5. I once again lowered the item obtained count to 1 below the current server count.
6. I reloaded the file and confirmed that the traps were not granted again.